### PR TITLE
[JAY-591] Add Github action for releasing the gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release and Deploy
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - lib/jay_api/version.rb
+
+jobs:
+  build:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create the tag and the release
+      id-token: write # Needed to push to rubygems.org as a trusted publisher
+    environment: release
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.7
+    - name: Build
+      run: |
+        bundler install
+        rake clobber
+        rake build
+    - name: Get Version
+      run: |
+        echo "GEM_VERSION=$(bundler exec ruby -e 'require "jay_api/version"; print JayAPI::VERSION')" | tee -a $GITHUB_ENV
+    - name: Create Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Github Actions
+        TAG_NAME: ${{ env.GEM_VERSION }}
+        NOTES: "[Changelog](${{ github.server_url }}/${{ github.repository }}/blob/${{ env.GEM_VERSION }}/CHANGELOG.md)"
+        TITLE: Release ${{ env.GEM_VERSION }}
+        TARGET: ${{ github.ref_name }}
+      run: |
+        gh release create $TAG_NAME --notes "$NOTES" --title "$TITLE" --target $TARGET pkg/jay_api-*.gem
+    - name: Configure trusted publishing credentials
+      uses: rubygems/configure-rubygems-credentials@v1.0.0
+    - name: Deploy
+      run: |
+        gem push pkg/jay_api-*.gem

--- a/lib/jay_api/elasticsearch/client.rb
+++ b/lib/jay_api/elasticsearch/client.rb
@@ -4,7 +4,7 @@ require 'elasticsearch/api/namespace/tasks'
 require 'elasticsearch/transport/transport/errors'
 require 'faraday/error'
 
-require 'jay_api/abstract/connection'
+require_relative '../abstract/connection'
 
 module JayAPI
   module Elasticsearch


### PR DESCRIPTION
This Github action runs whenever a Pull Request that changes the `lib/jay_api/version.rb` file is merged.

It builds the gem, creates a release (with a corresponding tag) and pushes the generated gem package to rubygems.org. It uses Rubygems's trusted publishers system hence there is no need for an OTP code.