### PR TITLE
Add Elasticsearch 'Max' aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- Added the `Aggregations::Max` class. To model Elasticsearch's `max`
+  aggregation type.
+
 ## [27.0.0] - 2025-01-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 ## [Unreleased]
 
 ### Added
+- The `max` method to the `QueryBuilders::Aggregations` class.
 - Added the `Aggregations::Max` class. To model Elasticsearch's `max`
   aggregation type.
 

--- a/documentation/source/user_guidelines/elasticsearch/aggregations.rst
+++ b/documentation/source/user_guidelines/elasticsearch/aggregations.rst
@@ -109,6 +109,39 @@ This would produce the following query:
      }
    }
 
+max
+---
+
+This is a single-value aggregation that calculates the maximum value in the
+specified field among all matched documents. Detailed information on how to use
+this type of aggregation can be found on `Elasticsearch's documentation on the Max aggregation`_
+
+Code example:
+
+.. code-block:: ruby
+
+   query_builder = JayAPI::Elasticsearch::QueryBuilder.new
+   query_builder.aggregations.max('max_price', field: 'price')
+
+This would produce the following query:
+
+.. code-block:: json
+
+   {
+     "query": {
+       "match_all": { }
+     },
+     "aggs": {
+       "max_price": {
+         "max": {
+           "field": "price"
+         }
+       }
+     }
+   }
+
+.. _`Elasticsearch's documentation on the Max aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
+
 value_count
 -----------
 

--- a/lib/jay_api/elasticsearch/query_builder/aggregations.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations.rb
@@ -7,6 +7,7 @@ require_relative 'aggregations/avg'
 require_relative 'aggregations/filter'
 require_relative 'aggregations/scripted_metric'
 require_relative 'aggregations/sum'
+require_relative 'aggregations/max'
 require_relative 'aggregations/terms'
 require_relative 'aggregations/value_count'
 require_relative 'aggregations/top_hits'
@@ -78,6 +79,16 @@ module JayAPI
             ::JayAPI::Elasticsearch::QueryBuilder::Aggregations::ScriptedMetric.new(
               name, map_script: map_script, combine_script: combine_script,
                     reduce_script: reduce_script, init_script: init_script
+            )
+          )
+        end
+
+        # Adds a +max+ type aggregation. For information about the parameters
+        # @see JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max#initialize
+        def max(name, field:)
+          add(
+            ::JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max.new(
+              name, field: field
             )
           )
         end

--- a/lib/jay_api/elasticsearch/query_builder/aggregations/max.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations/max.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative 'aggregation'
+
+module JayAPI
+  module Elasticsearch
+    class QueryBuilder
+      class Aggregations
+        # Represents a +max+ aggregation in Elasticsearch.
+        # Information on this type of aggregation can be found here:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
+        class Max < ::JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation
+          attr_reader :field, :missing
+
+          # @param [String] name The name used by Elasticsearch to identify each
+          #   of the aggregations.
+          # @param [String] field The field whose values should be added-up
+          def initialize(name, field:)
+            super(name)
+
+            @field = field
+            @missing = missing
+          end
+
+          # @raise [JayAPI::Elasticsearch::QueryBuilder::Aggregations::Errors::AggregationsError]
+          #   Is always raised. The Max aggregation cannot have nested aggregations.
+          def aggs
+            no_nested_aggregations('Max')
+          end
+
+          # @return [self] A copy of the receiver.
+          def clone
+            self.class.new(name, field: field)
+          end
+
+          # @return [Hash] The Hash representation of the +Aggregation+.
+          #   Properly formatted for Elasticsearch.
+          def to_h
+            super do
+              {
+                max: {
+                  field: field
+                }
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jay_api/elasticsearch/query_builder/aggregations/max_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/aggregations/max_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'jay_api/elasticsearch/query_builder/aggregations/max'
+
+require_relative 'aggregation_shared'
+
+RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max do
+  subject(:max) { described_class.new(name, **constructor_params) }
+
+  let(:name) { 'max_price' }
+  let(:field) { 'price' }
+
+  let(:constructor_params) do
+    { field: field }
+  end
+
+  describe '#aggs' do
+    subject(:method_call) { max.aggs }
+
+    let(:expected_message) { 'The Max aggregation cannot have nested aggregations.' }
+
+    it_behaves_like 'JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation#no_nested_aggregations'
+  end
+
+  describe '#clone' do
+    subject(:method_call) { max.clone }
+
+    it 'returns an instance of the same class' do
+      expect(method_call).to be_an_instance_of(described_class)
+    end
+
+    it 'does not return the same object' do
+      expect(method_call).not_to be(max)
+    end
+
+    it "has the same 'name'" do
+      expect(method_call.name).to be(max.name)
+    end
+
+    it "has the same 'field'" do
+      expect(method_call.field).to be(max.field)
+    end
+  end
+
+  describe '#to_h' do
+    subject(:method_call) { aggregation.to_h }
+
+    let(:aggregation) { max }
+
+    let(:expected_hash) do
+      {
+        'max_price' => {
+          max: { field: 'price' }
+        }
+      }
+    end
+
+    it_behaves_like 'JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation#to_h'
+
+    it 'returns the expected Hash' do
+      expect(method_call).to eq(expected_hash)
+    end
+  end
+end

--- a/spec/jay_api/elasticsearch/query_builder/aggregations_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/aggregations_spec.rb
@@ -186,6 +186,40 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations do
     end
   end
 
+  describe '#max' do
+    subject(:method_call) do
+      aggregations.max(
+        name, field: field
+      )
+    end
+
+    let(:name) { 'max_price' }
+    let(:field) { 'price' }
+
+    let(:max) do
+      instance_double(
+        JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max,
+        to_h: { terms: 'Max#to_h' }
+      )
+    end
+
+    before do
+      allow(JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max)
+        .to receive(:new).and_return(max)
+    end
+
+    it 'creates the Max instance with the expected parameters' do
+      expect(JayAPI::Elasticsearch::QueryBuilder::Aggregations::Max)
+        .to receive(:new).with(name, field: field)
+
+      method_call
+    end
+
+    it 'adds the Max instance to the array of aggregations' do
+      expect { method_call }.to change(aggregations, :to_h).to(aggs: { terms: 'Max#to_h' })
+    end
+  end
+
   describe '#sum' do
     subject(:method_call) do
       aggregations.sum(


### PR DESCRIPTION
The added 'Max' aggregation is of a metric type which allows to sort other aggregations based on custom
'Max' aggregations. The following is a concrete example of an aggregation that requires a 'Max' aggregation:

```
{
  aggs: {
    sut_revisions: {
      terms: {
        field: "sut_revision.keyword",
        size: 100,
        order: { timestamp: "desc" }
      },
      aggs: {
        timestamp: {
          max: {
            field: "scope.exported_at"
          }
        }
      }
    }
  }
}
```
Note that this will return the different 'sut_revision's ordered by the 'exported_at' timestamp.
