### PR TITLE
Add missing Elasticsearch modules and requires

### DIFF
--- a/lib/jay_api.rb
+++ b/lib/jay_api.rb
@@ -3,6 +3,7 @@
 require 'jay_api/version'
 
 require_relative 'jay_api/rspec'
+require_relative 'jay_api/elasticsearch'
 
 # Top-level namespace for the Gem
 module JayAPI

--- a/lib/jay_api/elasticsearch.rb
+++ b/lib/jay_api/elasticsearch.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'elasticsearch/async'
+require_relative 'elasticsearch/batch_counter'
+require_relative 'elasticsearch/client'
+require_relative 'elasticsearch/client_factory'
+require_relative 'elasticsearch/errors'
+require_relative 'elasticsearch/index'
+require_relative 'elasticsearch/query_builder'
+require_relative 'elasticsearch/query_results'
+require_relative 'elasticsearch/response'
+require_relative 'elasticsearch/search_after_results'
+require_relative 'elasticsearch/tasks'
+require_relative 'elasticsearch/time'
+
+module JayAPI
+  # Namespace for all Elasticsearch related classes.
+  module Elasticsearch; end
+end

--- a/lib/jay_api/elasticsearch/errors.rb
+++ b/lib/jay_api/elasticsearch/errors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'errors/elasticsearch_error'
+require_relative 'errors/end_of_query_results_error'
+require_relative 'errors/query_execution_error'
+require_relative 'errors/query_execution_failure'
+require_relative 'errors/query_execution_timeout'
+require_relative 'errors/search_after_error'
+
+module JayAPI
+  module Elasticsearch
+    # Namespace for all error classes related to Elasticsearch
+    module Errors; end
+  end
+end

--- a/lib/jay_api/elasticsearch/query_builder.rb
+++ b/lib/jay_api/elasticsearch/query_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'query_builder/aggregations'
+require_relative 'query_builder/errors'
 require_relative 'query_builder/query_clauses'
 require_relative 'query_builder/script'
 

--- a/lib/jay_api/elasticsearch/query_builder/errors.rb
+++ b/lib/jay_api/elasticsearch/query_builder/errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'errors/query_builder_error'
+
+module JayAPI
+  module Elasticsearch
+    class QueryBuilder
+      # Namespace for the error classes related to the QueryBuilder
+      module Errors; end
+    end
+  end
+end


### PR DESCRIPTION
Without these in place some of the Elasticsearch related classes did not get loaded when the console was invoked.

Having these in place also ensures an accurate code-coverage report since the files will be loaded even if they are never explicitly loaded by the tests, hence showing up as not covered in the report.