### PR TITLE
[JAY-495] Allow QueryBuilder#source to take false, arrays and hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- `QueryBuilder#source` can now take `false`, `Array` and `Hash` in addition to
+  simple strings.
+
 ## [27.1.0] - 2025-02-19
 
 ### Added

--- a/documentation/source/user_guidelines/elasticsearch/query_builder.rst
+++ b/documentation/source/user_guidelines/elasticsearch/query_builder.rst
@@ -144,9 +144,27 @@ Example:
 With the above query only the attributes inside the nested structure ``obj``
 will be returned.
 
-.. note::
+It is also possible to completely remove the document's source from the result
+by passing ``false`` as parameter:
 
-  Only string type expressions are accepted for this clause at the moment.
+.. code-block:: ruby
+
+   query_builder.source(false)
+
+Elasticsearch also allows the use of arrays to grab elements from multiple
+objects:
+
+.. code-block:: ruby
+
+   query_builder.source(%w[test_case.* meta_data.*])
+
+And the use of Hashes to include or exclude parts of the document, for example:
+
+.. code-block:: ruby
+
+   query_builder.source(
+     { includes: 'test_case.*' , excludes: 'test_case.test_steps'}
+   )
 
 #to_h and #to_query
 -------------------

--- a/lib/jay_api/elasticsearch/query_builder.rb
+++ b/lib/jay_api/elasticsearch/query_builder.rb
@@ -84,10 +84,13 @@ module JayAPI
       end
 
       # Adds a +_source+ clause to the query.
-      # @param [String] filter_expr Expression used for filtering source.
+      # @param [FalseClass, String, Array<String>, Hash] filter_expr Expression
+      #   used for source filtering.
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering
+      #   For more information on what kind of expressions are allowed.
       # @return [QueryBuilder] itself so that other methods can be chained.
       def source(filter_expr)
-        check_argument(filter_expr, 'source', String)
+        check_argument(filter_expr, 'source', FalseClass, String, Array, Hash)
         @source = filter_expr
         self
       end
@@ -178,7 +181,7 @@ module JayAPI
         query_hash = {}
         query_hash[:from] = @from if @from
         query_hash[:size] = @size if @size
-        query_hash[:_source] = @source if @source
+        query_hash[:_source] = @source unless @source.nil?
         query_hash[:query] = query.to_h
 
         if @sort.any?

--- a/lib/jay_api/elasticsearch/query_builder.rb
+++ b/lib/jay_api/elasticsearch/query_builder.rb
@@ -150,12 +150,15 @@ module JayAPI
       # @param [Object] value The value of the argument.
       # @param [String] argument_name The name of the argument (for the error
       #   message).
-      # @param [Class] expected_type The expected type of +value+
-      # @raise [ArgumentError] If the value is not an instance of the class.
-      def check_argument(value, argument_name, expected_type)
-        return if value.is_a?(expected_type)
+      # @param [Class, Array<Class>] allowed_types The list of classes that
+      #   +value+ might have.
+      # @raise [ArgumentError] If the value is not an instance of the any of the
+      #   classes in +allowed_types+.
+      def check_argument(value, argument_name, *allowed_types)
+        return if allowed_types.any? { |allowed_type| value.is_a?(allowed_type) }
 
-        raise ArgumentError, "Expected `#{argument_name}` to be #{expected_type}, #{value.class} given"
+        raise ArgumentError, "Expected `#{argument_name}` to be one of: " \
+                             "#{allowed_types.map(&:to_s).join(', ')} but #{value.class} was given"
       end
 
       # Checks that the given argument is positive (>= 0)

--- a/spec/jay_api/elasticsearch/query_builder_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder do
         expect { query_builder.from 'five' }
           .to raise_error(
             ArgumentError,
-            'Expected `from` to be Integer, String given'
+            'Expected `from` to be one of: Integer but String was given'
           )
       end
     end
@@ -212,18 +212,22 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder do
   end
 
   describe '#source' do
+    subject(:method_call) { query_builder.source(filter_expr) }
+
+    let(:filter_expr) { 'obj.*' }
+
     context 'with a value which is not a String' do
       it 'raises an ArgumentError' do
         expect { query_builder.source [] }
           .to raise_error(
             ArgumentError,
-            'Expected `source` to be String, Array given'
+            'Expected `source` to be one of: String but Array was given'
           )
       end
     end
 
     it 'returns itself' do
-      expect(query_builder.source('obj.*')).to eq(query_builder)
+      expect(method_call).to eq(query_builder)
     end
   end
 
@@ -237,7 +241,7 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder do
         expect { query_builder.size 'five' }
           .to raise_error(
             ArgumentError,
-            'Expected `size` to be Integer, String given'
+            'Expected `size` to be one of: Integer but String was given'
           )
       end
 
@@ -263,7 +267,7 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder do
         expect { query_builder.sort('name') }
           .to raise_error(
             ArgumentError,
-            'Expected `sort` to be Hash, String given'
+            'Expected `sort` to be one of: Hash but String was given'
           )
       end
     end
@@ -295,7 +299,7 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder do
 
       it 'raises an ArgumentError' do
         expect { method_call }.to raise_error(
-          ArgumentError, 'Expected `field` to be String, Array given'
+          ArgumentError, 'Expected `field` to be one of: String but Array was given'
         )
       end
     end


### PR DESCRIPTION
Change the `QueryBuilder#source` method to allow `filter_expr` to take `false`, arrays and hashes in addition to simple strings.

The main driver behind this change is allowing the use of `false` to remove the document's source from the result JSON. `Array` and `Hash` are being added in order to match the method's implementation to Elasticsearch's documentation.