### PR TITLE
[RELEASE] Version 27.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [27.2.0] - 2025-02-28
+
 ### Added
 - `QueryBuilder#source` can now take `false`, `Array` and `Hash` in addition to
   simple strings.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '27.1.0'
+  VERSION = '27.2.0'
 end


### PR DESCRIPTION
In this version:

### Added
- `QueryBuilder#source` can now take `false`, `Array` and `Hash` in addition to simple strings.