### PR TITLE
[JAY-639] Fix PropertiesFetcher#last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Fixed
+- `PropertiesFetcher#last` now correctly returns the last set of properties
+  (ordered chronologically).
+
 ## [27.2.0] - 2025-02-28
 
 ### Added

--- a/lib/jay_api/properties_fetcher.rb
+++ b/lib/jay_api/properties_fetcher.rb
@@ -129,7 +129,7 @@ module JayAPI
     # @return [Hash, nil] The last set of properties (ordered chronologically)
     #   or +nil+ if no properties are found.
     def last
-      sort_records('desc').size(1)
+      sort_records('asc').size(1)
       fetch_properties.last
     end
 

--- a/spec/jay_api/properties_fetcher_spec.rb
+++ b/spec/jay_api/properties_fetcher_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe JayAPI::PropertiesFetcher do
 
     shared_examples_for '#last' do
       it 'adds a sorting clause to the query' do
-        expect(query_builder).to receive(:sort).with('timestamp' => 'desc')
+        expect(query_builder).to receive(:sort).with('timestamp' => 'asc')
         method_call
       end
 


### PR DESCRIPTION
PropertiesFetcher#last was sorting the records in descending order and then taking the last one, effectively meaning that it returned the first one.

This change fixes the issue by sorting the records in ascending order instead.