### PR TITLE
[RELEASE] Version 27.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [27.2.1] - 2025-03-14
+
 ### Fixed
 - `PropertiesFetcher#last` now correctly returns the last set of properties
   (ordered chronologically).

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '27.2.0'
+  VERSION = '27.2.1'
 end


### PR DESCRIPTION
In this release:

### Fixed
- `PropertiesFetcher#last` now correctly returns the last set of properties
  (ordered chronologically).