### PR TITLE
[RELEASE] Version 27.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [27.3.0] - 2025-04-04
+
 ### Added
 - The `Aggregations::Cardinality` class and the `Aggregations#cardinality`
   method. They make it possible to use Elasticsearch's `cardinality`

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '27.2.1'
+  VERSION = '27.3.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `Aggregations::Cardinality` class and the `Aggregations#cardinality`
  method. They make it possible to use Elasticsearch's `cardinality`
  aggregations.

### Changed
- `GitilesHelper#gitiles_url` can now be called without a `path`. When no path
  is given the method generates a link to the given `refspec` instead.