### PR TITLE
[JAY-625] Add the Cardinality aggregation for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 ## [Unreleased]
 
 ### Added
-- The `Aggregations::Cardinality` class.
+- The `Aggregations::Cardinality` class and the `Aggregations#cardinality`
+  method. They make it possible to use Elasticsearch's `cardinality`
+  aggregations.
 
 ### Changed
 - `GitilesHelper#gitiles_url` can now be called without a `path`. When no path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- The `Aggregations::Cardinality` class.
+
 ### Changed
 - `GitilesHelper#gitiles_url` can now be called without a `path`. When no path
   is given the method generates a link to the given `refspec` instead.

--- a/documentation/source/user_guidelines/elasticsearch/aggregations.rst
+++ b/documentation/source/user_guidelines/elasticsearch/aggregations.rst
@@ -210,6 +210,37 @@ This would generate the following query:
      }
    }
 
+cardinality
+-----------
+
+This is a single-value aggregation that counts the **approximate** number of
+unique values that a field has in the index.
+
+Detailed information on how to use this type of aggregation can be found on
+`Elasticsearch's documentation on the Cardinality aggregation`_
+
+Code example:
+
+.. code-block:: ruby
+
+   query_builder = JayAPI::Elasticsearch::QueryBuilder.new
+   query_builder.aggregations.sum('type_count', field: 'type')
+
+This would produce the following query:
+
+.. code-block:: json
+
+   {
+     "query": { "match_all": {} },
+     "aggs": {
+       "type_count": {
+         "cardinality": {
+           "field": "type"
+         }
+       }
+     }
+   }
+
 scripted_metric
 ---------------
 
@@ -267,5 +298,6 @@ The code above would produce the following query:
 .. _`Elasticsearch's documentation on the Sum aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
 .. _`Elasticsearch's documentation on the Value Count aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
 .. _`Elasticsearch's documentation on the Filter aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
+.. _`Elasticsearch's documentation on the Cardinality aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
 .. _`Elasticsearch's documentation on the Scripted Metric aggregation`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
 .. _`Painless`: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-painless.html

--- a/lib/jay_api/elasticsearch/query_builder/aggregations.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations.rb
@@ -4,6 +4,7 @@ require 'forwardable'
 
 require_relative 'aggregations/aggregation'
 require_relative 'aggregations/avg'
+require_relative 'aggregations/cardinality'
 require_relative 'aggregations/filter'
 require_relative 'aggregations/scripted_metric'
 require_relative 'aggregations/sum'

--- a/lib/jay_api/elasticsearch/query_builder/aggregations.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations.rb
@@ -100,6 +100,16 @@ module JayAPI
           add(::JayAPI::Elasticsearch::QueryBuilder::Aggregations::Filter.new(name, &block))
         end
 
+        # Adds a +cardinality+ type aggregation. For more information about the parameters
+        # @see JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality#initialize
+        def cardinality(name, field:)
+          add(
+            ::JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality.new(
+              name, field: field
+            )
+          )
+        end
+
         # Returns a Hash with the correct format for the current list of
         # aggregations. For example:
         #

--- a/lib/jay_api/elasticsearch/query_builder/aggregations/cardinality.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations/cardinality.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'aggregation'
+
+module JayAPI
+  module Elasticsearch
+    class QueryBuilder
+      class Aggregations
+        # Represents a +cardinality+ aggregation in Elasticsearch.
+        # Information on this type of aggregation can be found here:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
+        class Cardinality < ::JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation
+          attr_reader :field
+
+          # @param [String] name The name used by Elasticsearch to identify each
+          #   of the aggregations.
+          # @param [String] field The field whose cardinality (number of unique
+          #   values) should be calculated.
+          def initialize(name, field:)
+            super(name)
+
+            @field = field
+          end
+
+          # @raise [JayAPI::Elasticsearch::QueryBuilder::Aggregations::Errors::AggregationsError]
+          #   Is always raised. The Cardinality aggregation cannot have nested
+          #   aggregations.
+          def aggs
+            no_nested_aggregations('Cardinality')
+          end
+
+          # @return [self] A copy of the receiver.
+          def clone
+            self.class.new(name, field: field)
+          end
+
+          # @return [Hash] The Hash representation of the +Aggregation+.
+          #   Properly formatted for Elasticsearch.
+          def to_h
+            super do
+              {
+                cardinality: {
+                  field: field
+                }
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jay_api/elasticsearch/query_builder/aggregations/cardinality_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/aggregations/cardinality_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'jay_api/elasticsearch/query_builder/aggregations/cardinality'
+
+require_relative 'aggregation_shared'
+
+RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality do
+  subject(:cardinality) { described_class.new(name, **constructor_params) }
+
+  let(:name) { 'type_count' }
+  let(:field) { 'type' }
+
+  let(:constructor_params) do
+    { field: field }
+  end
+
+  describe '#aggs' do
+    subject(:method_call) { cardinality.aggs }
+
+    let(:expected_message) { 'The Cardinality aggregation cannot have nested aggregations.' }
+
+    it_behaves_like 'JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation#no_nested_aggregations'
+  end
+
+  describe '#clone' do
+    subject(:method_call) { cardinality.clone }
+
+    it 'returns an instance of the same class' do
+      expect(method_call).to be_an_instance_of(described_class)
+    end
+
+    it 'does not return the same object' do
+      expect(method_call).not_to be(cardinality)
+    end
+
+    it "has the same 'name'" do
+      expect(method_call.name).to be(cardinality.name)
+    end
+
+    it "has the same 'field'" do
+      expect(method_call.field).to be(cardinality.field)
+    end
+  end
+
+  describe '#to_h' do
+    subject(:method_call) { cardinality.to_h }
+
+    let(:aggregation) { cardinality }
+
+    let(:expected_hash) do
+      {
+        'type_count' => {
+          cardinality: { field: 'type' }
+        }
+      }
+    end
+
+    it_behaves_like 'JayAPI::Elasticsearch::QueryBuilder::Aggregations::Aggregation#to_h'
+
+    it 'returns the expected Hash' do
+      expect(method_call).to eq(expected_hash)
+    end
+  end
+end

--- a/spec/jay_api/elasticsearch/query_builder/aggregations_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/aggregations_spec.rb
@@ -339,6 +339,36 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations do
     end
   end
 
+  describe '#cardinality' do
+    subject(:method_call) do
+      aggregations.cardinality(name, field: field)
+    end
+
+    let(:name) { 'type_count' }
+    let(:field) { 'type' }
+
+    let(:cardinality) do
+      instance_double(
+        JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality,
+        to_h: { 'cardinality' => { '#to_h' => {} } }
+      )
+    end
+
+    before do
+      allow(JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality)
+        .to receive(:new).and_return(cardinality)
+    end
+
+    it 'creates the Cardinality instance with the expected parameters' do
+      expect(JayAPI::Elasticsearch::QueryBuilder::Aggregations::Cardinality).to receive(:new).with(name, field: field)
+      method_call
+    end
+
+    it 'adds the Cardinality instance to the array of aggregations' do
+      expect { method_call }.to change(aggregations, :to_h).to(aggs: { 'cardinality' => { '#to_h' => {} } })
+    end
+  end
+
   describe '#top_hits' do
     subject(:method_call) do
       aggregations.top_hits(name, size: size)


### PR DESCRIPTION
The Cardinality aggregation counts the **approximate** number of unique values that a field has in the index.

The changes in this Pull Request add the `Aggregations::Cardinality` class, the `Aggregations#cardinality` method and the documentation for the newly added feature.