### PR TITLE
[JAY-409] Add #ping to Elasticsearch::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- The `#ping` method to `Elasticsearch::Client`
+
 ## [27.3.0] - 2025-04-04
 
 ### Added

--- a/lib/jay_api/elasticsearch/client.rb
+++ b/lib/jay_api/elasticsearch/client.rb
@@ -3,6 +3,7 @@
 require 'elasticsearch/api/namespace/tasks'
 require 'elasticsearch/transport/transport/errors'
 require 'faraday/error'
+require 'forwardable'
 
 require_relative '../abstract/connection'
 
@@ -13,6 +14,8 @@ module JayAPI
     # rescue the error up to a few times and re-try the connection. This way the
     # connection to Elasticsearch will be more robust.
     class Client
+      extend Forwardable
+
       # The errors that, if raised, must cause a retry of the connection.
       ERRORS = [
         ::Elasticsearch::Transport::Transport::ServerError,
@@ -32,6 +35,11 @@ module JayAPI
       ].freeze
 
       attr_reader :transport_client, :logger, :max_attempts, :wait_strategy
+
+      # @return [Boolean] True if there is connectivity to the cluster, false otherwise.
+      # @raise [Transport::Errors::Forbidden] If the user has no permissions to
+      #   ping the cluster.
+      def_delegator :transport_client, :ping
 
       # @param [Elasticsearch::Transport::Client] transport_client The Client
       #   object that will be wrapped.

--- a/spec/integration/jay_api/elasticsearch/client_spec.rb
+++ b/spec/integration/jay_api/elasticsearch/client_spec.rb
@@ -287,4 +287,13 @@ RSpec.describe JayAPI::Elasticsearch::Client do
 
     it_behaves_like 'JayAPI::Elasticsearch::Client#<any_method>'
   end
+
+  describe '#ping' do
+    subject(:method_call) { client.ping }
+
+    it 'forwards the call to the underlying transport client' do
+      expect(transport_client).to receive(:ping)
+      method_call
+    end
+  end
 end


### PR DESCRIPTION
The method allows the user to ping the Elasticsearch cluster to check connectivity and latency, without the need for any previous knowledge about the cluster, like endpoint or index names.

The method just forwards the call to the underlying Elasticsearch Transport Client's `#ping` method. Which returns `true` when the ping is successful and `false` when it fails. Although, less common, it can also raise a `Transport::Errors::Forbidden` when the user doesn't have permissions to ping the cluster.