### PR TITLE
[RELEASE] Version 27.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [27.5.0] - 2025-04-22
+
 ### Added
 - The `Aggregations::DateHistogram` class and the `Aggregations#date_histogram`
   method. They make it possible to use Elasticsearch's `date_histogram`

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '27.4.0'
+  VERSION = '27.5.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `Aggregations::DateHistogram` class and the `Aggregations#date_histogram`
  method. They make it possible to use Elasticsearch's `date_histogram`
  aggregations.