### PR TITLE
[BUGFIX] Fix a bug in DateHistogram#to_h

### DIFF
--- a/lib/jay_api/elasticsearch/query_builder/aggregations/date_histogram.rb
+++ b/lib/jay_api/elasticsearch/query_builder/aggregations/date_histogram.rb
@@ -40,10 +40,12 @@ module JayAPI
           def to_h(&block)
             super do
               {
-                field: field,
-                calendar_interval: calendar_interval,
-                format: format
-              }.compact
+                date_histogram: {
+                  field: field,
+                  calendar_interval: calendar_interval,
+                  format: format
+                }.compact
+              }
             end
           end
         end

--- a/spec/jay_api/elasticsearch/query_builder/aggregations/date_histogram_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/aggregations/date_histogram_spec.rb
@@ -66,8 +66,10 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations::DateHistogram 
       let(:expected_hash) do
         {
           'sales_over_time' => {
-            field: 'date',
-            calendar_interval: 'month'
+            date_histogram: {
+              field: 'date',
+              calendar_interval: 'month'
+            }
           }
         }
       end
@@ -83,9 +85,11 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::Aggregations::DateHistogram 
       let(:expected_hash) do
         {
           'sales_over_time' => {
-            field: 'date',
-            calendar_interval: 'month',
-            format: 'yyyy-MM-dd'
+            date_histogram: {
+              field: 'date',
+              calendar_interval: 'month',
+              format: 'yyyy-MM-dd'
+            }
           }
         }
       end


### PR DESCRIPTION
The hash generated by the method was missing the `date_histogram` key. The keys were instead being added directly to the top-level hash.