### PR TITLE
[RELEASE] Version 27.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [27.5.1] - 2025-04-24
+
 ### Fixed
 - The `Aggregations::TopHits` class cloning. The nested aggregations are now
   also being cloned as expected.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '27.5.0'
+  VERSION = '27.5.1'
 end


### PR DESCRIPTION
This contains a fix to the cloning of the TopHits aggregation.