### PR TITLE
[JAY-653] Add Configuration#keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- ! The `#keys` method to the `Configuration` class. The method returns the
+  array of keys that the `Configuration` object has.
+
+  Note that the addition of this method means that it is no longer possible to
+  access the value of an attribute called `keys` via the dot syntax, however,
+  it is still possible to access its value using the brackets: `[]`
+
 ## [27.5.1] - 2025-04-24
 
 ### Fixed

--- a/lib/jay_api/configuration.rb
+++ b/lib/jay_api/configuration.rb
@@ -89,6 +89,12 @@ module JayAPI
       YAML.dump(deep_to_h.deep_stringify_keys)
     end
 
+    # @return [Array<Object>] An array with the keys (generally the name of the
+    #   attributes) that the configuration object has.
+    def keys
+      @table.keys
+    end
+
     private
 
     # Takes a value and transforms it in accordance to its type.

--- a/spec/jay_api/configuration_spec.rb
+++ b/spec/jay_api/configuration_spec.rb
@@ -106,6 +106,10 @@ RSpec.shared_examples_for 'JayAPI::Configuration.from_string' do
 end
 
 RSpec.describe JayAPI::Configuration do
+  subject(:configuration) { described_class.new(**constructor_params) }
+
+  let(:constructor_params) { {} }
+
   describe '.from_string' do
     subject(:method_call) { described_class.from_string(yaml) }
 
@@ -276,6 +280,46 @@ RSpec.describe JayAPI::Configuration do
 
     it 'prints the configuration as a parsed YAML string' do
       expect(method_call).to eq(expected_yaml_string)
+    end
+  end
+
+  describe '#keys' do
+    subject(:method_call) { configuration.keys }
+
+    context 'when the Configuration object is empty' do
+      it 'returns an empty Array' do
+        expect(method_call).to be_an(Array) & be_empty
+      end
+    end
+
+    context 'when the Configuration object has elements' do
+      let(:constructor_params) do
+        { fruits: %w[Apple Banana Cherry], basket: true, authentication: 'basic', url: 'http://localhost:4400' }
+      end
+
+      it 'returns the expected array of keys' do
+        expect(method_call).to eq(%i[fruits basket authentication url])
+      end
+    end
+
+    context "when the Configuration object has a key called 'keys'" do
+      let(:constructor_params) do
+        { keys: %w[foo bar baz], values: [1, 3, 5] }
+      end
+
+      context 'when the dot-syntax is used' do
+        it 'returns the expected array of keys' do
+          expect(method_call).to eq(%i[keys values])
+        end
+      end
+
+      context 'when the brackets are used' do
+        subject(:method_call) { configuration[:keys] }
+
+        it 'returns the expected value' do
+          expect(method_call).to eq(%w[foo bar baz])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The method allows the caller to get the list of keys that the configuration object has. This could be used to iterate over the elements in the `Configuration` object or to validate the object's structure without having to turn it into a Hash first (`#to_h`).

Note that the addition of this method means that it is no longer possible to access the value of a an attribute called `keys` via the dot syntax, however, it is still possible to access its value using the brackets: `[]`