### PR TITLE
[RELEASE] Version 28.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [28.1.0] - 2025-05-19
+
 ### Added
 - The `#stats` method to the `Elasticsearch::Client` class. The method returns
   an object that can be used to retrieve statistics about the Cluster. For the

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '28.0.0'
+  VERSION = '28.1.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `#stats` method to the `Elasticsearch::Client` class. The method returns
  an object that can be used to retrieve statistics about the Cluster. For the
  moment only `#indices` is available, which returns index-related statistics.