### PR TITLE
[RELEASE] Version 28.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [28.2.0] - 2025-05-30
+
 ### Added
 - The `#nodes` method to the `Elasticsearch::Stats` class. This method gives the
   user access to the node-related statistics of the Elasticsearch cluster.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '28.1.0'
+  VERSION = '28.2.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `#nodes` method to the `Elasticsearch::Stats` class. This method gives the
  user access to the node-related statistics of the Elasticsearch cluster.