### PR TITLE
[RELEASE] Version 28.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [28.3.0] - 2025-06-05
+
 ### Added
 - The `Aggregations::Composite` class and the `Aggregations#composite` method.
   They make it possible to use Elasticsearch's `composite` aggregations.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '28.2.0'
+  VERSION = '28.3.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `Aggregations::Composite` class and the `Aggregations#composite` method.
  They make it possible to use Elasticsearch's `composite` aggregations.