### PR TITLE
[RELEASE] Version 28.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [28.4.0] - 2025-08-26
+
 ### Added
 - The `Elasticsearch::Indexes` class. A class which allows multiple indexes to
   be used (fed or queried) at the same time.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '28.3.0'
+  VERSION = '28.4.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `Elasticsearch::Indexes` class. A class which allows multiple indexes to
  be used (fed or queried) at the same time.