### PR TITLE
[ELITERT-1275] Update git dependency from '~> 1' to '~> 3'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 ## [Unreleased]
 
 ### Changed
+- ! Updated the `git` dependency from `~> 1, >= 1.8.0-1` to `~> 3`.
 - ! Increased the minimum Ruby version requirement to 3.1.0
 
 ## [28.4.0] - 2025-08-26

--- a/jay_api.gemspec
+++ b/jay_api.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '~> 7'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1'
   spec.add_runtime_dependency 'elasticsearch', '~> 7', '<= 7.9.0'
-  spec.add_runtime_dependency 'git', '~> 1', '>= 1.8.0-1'
+  spec.add_runtime_dependency 'git', '~> 3'
   spec.add_runtime_dependency 'logging', '~> 2'
   spec.add_runtime_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
This is needed because version 3.0.0 of the git gem fixes a crash that occurred when the `#branch` method was called on a repository in a detached head.

This pull request depends on #37 