### PR TITLE
[RELEASE] Version 29.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.0.0] - 2025-08-28
+
 ### Changed
 - ! Updated the `git` dependency from `~> 1, >= 1.8.0-1` to `~> 3`.
 - ! Increased the minimum Ruby version requirement to 3.1.0

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '28.4.0'
+  VERSION = '29.0.0'
 end


### PR DESCRIPTION
In this release:

### Changed
- Updated the `git` dependency from `~> 1, >= 1.8.0-1` to `~> 3`.
- Increased the minimum Ruby version requirement to 3.1.0