### PR TITLE
[JAY-737] Add the Index#force_merge method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
   when `active_support/core_ext/string` hadn't been loaded.
 
 ### Added
+- The `#force_merge` method to the `Elasticsearch::Index` class. This method
+  starts a Forced Segment Merge on the index.
 - The `#totals` method to `Elasticsearch::Stats::Index`, this gives the caller
   access to the index's total metrics.
 - The `Elasticsearch::Stats::Index::Totals` class. The class contains information

--- a/lib/jay_api/elasticsearch/errors.rb
+++ b/lib/jay_api/elasticsearch/errors.rb
@@ -6,6 +6,7 @@ require_relative 'errors/query_execution_error'
 require_relative 'errors/query_execution_failure'
 require_relative 'errors/query_execution_timeout'
 require_relative 'errors/search_after_error'
+require_relative 'errors/writable_index_error'
 
 module JayAPI
   module Elasticsearch

--- a/lib/jay_api/elasticsearch/errors/writable_index_error.rb
+++ b/lib/jay_api/elasticsearch/errors/writable_index_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../../errors/error'
+
+module JayAPI
+  module Elasticsearch
+    module Errors
+      # An error to be raised when an attempt is made to perform force_merge
+      # over an index which hasn't been set to be read-only.
+      class WritableIndexError < ::JayAPI::Errors::Error; end
+    end
+  end
+end


### PR DESCRIPTION
The method starts a forced segment merge on the index.

More information about this procedure can be found here: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge

The method does little in terms of logic, it basically forwards the request directly to the transport client. The only check it performs is making sure that the index has been set to read-only before starting the process.