### PR TITLE
[BUGFIX] Fix NoMethodError in Elasticsearch::Stats::Indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Fixed
+- A `NoMethodError` that was being raised by `Elasticsearch::Stats::Indices`
+  when `active_support/core_ext/string` hadn't been loaded.
+
 ### Added
 - It is now possible to configure the type used by the `RSpec::TestDataCollector`
   class when pushing documents to Elasticsearch. If no type is specified in the

--- a/lib/jay_api/elasticsearch/stats/indices.rb
+++ b/lib/jay_api/elasticsearch/stats/indices.rb
@@ -10,7 +10,7 @@ module JayAPI
       class Indices
         # A lambda used to select / reject system indices (indices whose name
         # starts with dot).
-        SYSTEM_SELECTOR = ->(name, _data) { name.starts_with?('.') }
+        SYSTEM_SELECTOR = ->(name, _data) { name.start_with?('.') }
 
         # @param [Hash{String=>Hash}] indices A +Hash+ with the information
         #   about the indices. Its keys are the names of the indices, its values


### PR DESCRIPTION
Fixes a NoMethodError raised by the `#system` and `#user` methods of the `Elasticsearch::Stats::Indices` class when ActiveSupport's String extensions hadn't been loaded yet.

The reason for the error was the use of the `#starts_with?` (from ActiveSupport) method instead of Ruby's built-in `#start_with?` method.