### PR TITLE
[BUGFIX] Fix NameError when requiring the Client class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 ## [Unreleased]
 
 ### Fixed
+- A `NameError` that was being raised when `jay_api/elasticsearch/client` was
+  required without requiring `elasticsearch`.
 - A `NoMethodError` that was being raised by `Elasticsearch::Stats::Indices`
   when `active_support/core_ext/string` hadn't been loaded.
 

--- a/lib/jay_api/elasticsearch/client.rb
+++ b/lib/jay_api/elasticsearch/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'elasticsearch/api/namespace/tasks'
+require 'timeout'
 require 'elasticsearch/transport/transport/errors'
 require 'faraday/error'
 require 'forwardable'


### PR DESCRIPTION
Fixes a `NameError` that occurred when requiring `'jay_api/elasticsearch/client'` without requiring `'elasticsearch'`. The error was happening because of two things:

1. The class's file was requiring `'elasticsearch/api/namespace/tasks'`, however, this file was not only not needed by the class but it cannot be directly required, because it tries to use Elasticsearch's `Common::Client` class without requiring it first, hence the `NameError`.

2. Requiring `'elasticsearch/transport/transport/errors'`, which is actually needed by the class, causes a `NameError` because it tries to use `Timeout::Error` without requiring `'timeout'` first. So, to fix the issue a require statement for `'timeout'` is being added.

This error was only happening when the class was required directly, so it is mostly visible in unit tests.