### PR TITLE
[RELEASE] Version 29.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.5.0] - 2026-02-23
+
 ### Fixed
 - A `NameError` that was being raised when `jay_api/elasticsearch/client` was
   required without requiring `elasticsearch`.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.4.0'
+  VERSION = '29.5.0'
 end


### PR DESCRIPTION
In this release:

### Fixed
- A `NameError` that was being raised when `jay_api/elasticsearch/client` was
  required without requiring `elasticsearch`.
- A `NoMethodError` that was being raised by `Elasticsearch::Stats::Indices`
  when `active_support/core_ext/string` hadn't been loaded.
### Added
- The `#force_merge` method to the `Elasticsearch::Index` class. This method
  starts a Forced Segment Merge on the index.
- The `#totals` method to `Elasticsearch::Stats::Index`, this gives the caller
  access to the index's total metrics.
- The `Elasticsearch::Stats::Index::Totals` class. The class contains information
  about an index's total metrics, for example, total number of documents, total
  size, etc.
- The `#settings` method to the `Elasticsearch::Index` class. This gives the
  caller access to the index's settings.
- The `Elasticsearch::Indices::Settings::Blocks` class. The class encapsulates
  an index's blocks settings (for example, whether the index is read-only).
- The `Elasticsearch::Indices::Settings` class. The class encapsulates an
  index's settings.
- It is now possible to configure the type used by the `RSpec::TestDataCollector`
  class when pushing documents to Elasticsearch. If no type is specified in the
  configuration the default type will be used.
- Allow the `Elasticsearch::Index` and `Elasticsearch::Indexes`'s `#push` method
  to receive a `type` parameter, just like `#index` does.