### PR TITLE
[RELEASE] Version 29.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.6.0] - 2026-03-16
+
 ### Deprecated
 - The `#task_by_id` method of the `Elasticsearch::Client` class.
 

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.5.0'
+  VERSION = '29.6.0'
 end


### PR DESCRIPTION
In this release:

### Deprecated
- The `#task_by_id` method of the `Elasticsearch::Client` class.

### Added
- The `#all` method to `JayAPI::Elasticsearch::Tasks`. The method returns the
  status of all running tasks on the Elasticsearch cluster.
- The `#tasks` method to `JayAPI::Elasticsearch::Client`. The method returns an
  instance of `JayAPI::Elasticsearch::Tasks`, which gives the user access to the
  status of the tasks running on the Elasticsearch cluster.