### PR TITLE
Upates Ruby version for the GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 3.1
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
     - name: Build
       run: |
         bundler install

--- a/.github/workflows/ruby-linters.yml
+++ b/.github/workflows/ruby-linters.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
     - name: Install Gems
       run: |
         bundler install

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1']
+        ruby-version: ['3.2']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Versions 3.1.x are no longer available on GitHub Actions, The following error is being thrown in the GitHub Actions logs:

```
Error: Error: Unavailable version 3.1.7 for ruby on ubuntu-24.04
```

So, all the actions that are using Ruby 3.1 are hereby updated to use Ruby 3.2 instead.