### PR TITLE
[RELEASE] Version 29.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.7.0] - 2026-04-28
+
 ### Added
 - The `#cluster` method to `JayAPI::Elasticsearch::Client`. The method returns
   an instance of `JayAPI::Elasticsearch::Cluster`.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.6.0'
+  VERSION = '29.7.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `#cluster` method to `JayAPI::Elasticsearch::Client`. The method returns
  an instance of `JayAPI::Elasticsearch::Cluster`.
- The `Elasticsearch::Cluster` class. The class gives the user access to
  cluster-level endpoints, currently including cluster health.