### PR TITLE
[ESRTEST-30704] Add the IDs query to QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+### Added
+- The `QueryClauses::IDs` class and the corresponding `#ids` method to the
+  `MatchClauses` module. This allows the use of Elasticsearch's
+  [ids](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-ids-query)
+  query with the Query Builder.
+
 ## [29.7.0] - 2026-04-28
 
 ### Added

--- a/documentation/source/user_guidelines/elasticsearch/query_builder.rst
+++ b/documentation/source/user_guidelines/elasticsearch/query_builder.rst
@@ -453,6 +453,17 @@ A `Regexp Query`_ will match documents that satisfies the specified pattern
     search engine. To match a term, the regular expression must match the entire
     string.
 
+ids
++++
+
+An `IDs Query`_ will match documents that have the given IDs in their ``_id``
+field.
+
+.. code-block:: ruby
+
+   # The documents matching the given IDs will be matched
+   query_builder.query.ids(ids: %w[eSO6FZ8BUAdcYcWLRszq of2yFZ8BXEjZhYMm9Goe w1KlFZ8BK-fBiJSF1ptV])
+
 #merge
 ------
 
@@ -535,4 +546,5 @@ Example:
 .. _`Range Query`: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
 .. _`Terms Query`: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
 .. _`Regexp Query`: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
+.. _`IDs Query`: https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-ids-query
 .. _`Sort search results`: https://www.elastic.co/docs/reference/elasticsearch/rest-apis/sort-search-results

--- a/lib/jay_api/elasticsearch/query_builder/query_clauses/ids.rb
+++ b/lib/jay_api/elasticsearch/query_builder/query_clauses/ids.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'query_clause'
+
+module JayAPI
+  module Elasticsearch
+    class QueryBuilder
+      class QueryClauses
+        # Represents an IDs query in Elasticsearch.
+        # Information about this type of query can be found here:
+        # https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-ids-query
+        class IDs < ::JayAPI::Elasticsearch::QueryBuilder::QueryClauses::QueryClause
+          attr_reader :ids
+
+          # @param [Array<String>] ids The ids of the documents to match.
+          def initialize(ids:)
+            super()
+
+            @ids = ids
+          end
+
+          # @return [Hash] The Hash that represents this query (in
+          #   Elasticsearch's DSL)
+          def to_h
+            {
+              ids: {
+                values: ids
+              }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jay_api/elasticsearch/query_builder/query_clauses/match_clauses.rb
+++ b/lib/jay_api/elasticsearch/query_builder/query_clauses/match_clauses.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'exists'
+require_relative 'ids'
 require_relative 'match_all'
 require_relative 'match_none'
 require_relative 'match_phrase'
@@ -114,6 +115,18 @@ module JayAPI
           #   If an error occurs when trying to add the query clause to the set.
           def regexp(**params)
             self << ::JayAPI::Elasticsearch::QueryBuilder::QueryClauses::Regexp.new(**params)
+          end
+
+          # Adds a +JayAPI::Elasticsearch::QueryBuilder::QueryClauses::IDs+
+          # clause to the Query Clauses set.
+          # @param [Hash] params The parameters for the +IDs+ class'
+          #   constructor.
+          # @see JayAPI::Elasticsearch::QueryBuilder::QueryClauses::IDs#initialize
+          # @return [self] Returns itself, so that other methods can be chained.
+          # @raise [JayAPI::Elasticsearch::QueryBuilder::Errors::QueryBuilderError]
+          #   If an error occurs when trying to add the query clause to the set.
+          def ids(**params)
+            self << ::JayAPI::Elasticsearch::QueryBuilder::QueryClauses::IDs.new(**params)
           end
 
           # Adds a +JayAPI::Elasticsearch::QueryBuilder::QueryClauses::MatchAll+

--- a/spec/jay_api/elasticsearch/query_builder/query_clauses/ids_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/query_clauses/ids_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'jay_api/elasticsearch/query_builder/query_clauses/ids'
+
+# rubocop:disable RSpec/SpecFilePathFormat -- Avoid the name i_d_s_spec.rb
+RSpec.describe JayAPI::Elasticsearch::QueryBuilder::QueryClauses::IDs do
+  subject(:ids_clause) { described_class.new(ids: ids) }
+
+  let(:ids) { %w[1 4 100] }
+
+  describe '#to_h' do
+    subject(:method_call) { ids_clause.to_h }
+
+    let(:expected_hash) do
+      {
+        ids: {
+          values: %w[1 4 100]
+        }
+      }
+    end
+
+    it 'returns the expected Hash' do
+      expect(method_call).to eq(expected_hash)
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat

--- a/spec/jay_api/elasticsearch/query_builder/query_clauses/match_clauses_spec.rb
+++ b/spec/jay_api/elasticsearch/query_builder/query_clauses/match_clauses_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::QueryClauses::MatchClauses d
       method_call
       expect(test_instance).to include(clause_instance)
     end
+
+    context 'when an error occurs while adding the query clause to the set' do
+      let(:test_class) do
+        Class.new(Array) do
+          include JayAPI::Elasticsearch::QueryBuilder::QueryClauses::MatchClauses
+
+          def <<(_clause)
+            raise JayAPI::Elasticsearch::QueryBuilder::Errors::QueryBuilderError,
+                  'A boolean clause has been defined but no boolean sub-clauses were added'
+          end
+        end
+      end
+
+      it 'raises a JayAPI::Elasticsearch::QueryBuilder::Errors::QueryBuilderError' do
+        expect { method_call }.to raise_error(
+          JayAPI::Elasticsearch::QueryBuilder::Errors::QueryBuilderError,
+          'A boolean clause has been defined but no boolean sub-clauses were added'
+        )
+      end
+    end
   end
 
   describe '#match_phrase' do
@@ -105,6 +125,16 @@ RSpec.describe JayAPI::Elasticsearch::QueryBuilder::QueryClauses::MatchClauses d
     let(:params) { { field: 'sut_revision.keyword', value: '[0-9]{2}-[0-9]{2}-[0-9]{2}/.*' } }
 
     let(:clause_class) { JayAPI::Elasticsearch::QueryBuilder::QueryClauses::Regexp }
+
+    it_behaves_like '#match_phrase'
+  end
+
+  describe '#ids' do
+    subject(:method_call) { test_instance.ids(**params) }
+
+    let(:params) { { ids: %w[1 4 100] } }
+
+    let(:clause_class) { JayAPI::Elasticsearch::QueryBuilder::QueryClauses::IDs }
 
     it_behaves_like '#match_phrase'
   end


### PR DESCRIPTION
Adds the `QueryClauses::IDs` class and the corresponding `#ids` method to the `MatchClauses` module. This allows users to use Elasticsearch's IDs query, which allows matching documents by their [internal] IDs.