### PR TITLE
[RELEASE] Version 29.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.8.0] - 2026-07-06
+
 ### Deprecated
 - The `Elasticsearch::QueryBuilder::Script` class is now deprecated, please
   use `Elasticsearch::Script` instead.

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.7.0'
+  VERSION = '29.8.0'
 end


### PR DESCRIPTION
In this release:

### Deprecated
- The `Elasticsearch::QueryBuilder::Script` class is now deprecated, please use `Elasticsearch::Script` instead.
### Added
- The `#update` method to `JayAPI::Elasticsearch::Client`.
- The `QueryClauses::IDs` class and the corresponding `#ids` method to the `MatchClauses` module. This allows the use of Elasticsearch's [ids](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-ids-query) query with the Query Builder.