### PR TITLE
[RELEASE] Version 29.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.9.0] - 2026-08-04
+
 ### Added
 - The `JayAPI::Elasticsearch::Count` class.
 - The `#count` method to the `Indexable` module. The method returns the number

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.8.0'
+  VERSION = '29.9.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `JayAPI::Elasticsearch::Count` class.
- The `#count` method to the `Indexable` module. The method returns the number
  of documents in the `Index` or `Indexes`. A query can be provided to filter
  the documents that are counted.