### PR TITLE
Fix QueryResults#initialize's documentation

### DIFF
--- a/lib/jay_api/elasticsearch/query_results.rb
+++ b/lib/jay_api/elasticsearch/query_results.rb
@@ -24,7 +24,8 @@ module JayAPI
       # @param [JayAPI::Elasticsearch::Indexable] index The Elasticsearch
       #   index or indexes over which the query should be performed.
       # @param [Hash] query The query that produced the results.
-      # @param [JayAPI::Elasticsearch::Results] response An object containing Docs retrieved from Elasticsearch.
+      # @param [JayAPI::Elasticsearch::Response] response An object containing
+      #   Docs retrieved from Elasticsearch.
       # @param [JayAPI::Elasticsearch::BatchCounter] batch_counter An object keeping track of the current batch.
       def initialize(index:, query:, response:, batch_counter: nil)
         @index = index


### PR DESCRIPTION
The documentation for `response` was referencing a non-existing class: `JayAPI::Elasticsearch::Results`, the correct class is `JayAPI::Elasticsearch::Response`.