### PR TITLE
[RELEASE] Version 29.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please mark backwards incompatible changes with an exclamation mark at the start
 
 ## [Unreleased]
 
+## [29.10.0] - 2026-08-21
+
 ### Added
 - The `JayAPI::Elasticsearch::QueryBuilder::QueryClauses::Prefix` class and the
   corresponding `#prefix` method to the `MatchClauses` module. This allows the

--- a/lib/jay_api/version.rb
+++ b/lib/jay_api/version.rb
@@ -2,5 +2,5 @@
 
 module JayAPI
   # JayAPI gem's semantic version
-  VERSION = '29.9.0'
+  VERSION = '29.10.0'
 end


### PR DESCRIPTION
In this release:

### Added
- The `JayAPI::Elasticsearch::QueryBuilder::QueryClauses::Prefix` class and the corresponding `#prefix` method to the `MatchClauses` module. This allows the use of Elasticsearch's [prefix](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html) query with the Query Builder.